### PR TITLE
将计算图的逆拓扑排序改为基于队列的拓扑排序

### DIFF
--- a/course4/include/runtime/runtime_ir.hpp
+++ b/course4/include/runtime/runtime_ir.hpp
@@ -99,7 +99,7 @@ private:
   InitGraphParams(const std::map<std::string, pnnx::Parameter> &params,
                   const std::shared_ptr<RuntimeOperator> &runtime_operator);
 
-  void ReverseTopo(const std::shared_ptr<RuntimeOperator> &root_op);
+  void TopoSort(const std::shared_ptr<RuntimeOperator> &root_op);
 
 private:
   enum class GraphState {


### PR DESCRIPTION
将计算图的逆拓扑排序改为基于队列的拓扑排序，省去后续的reverse操作，并且比原始的递归代码更好懂